### PR TITLE
enhance: include deprecation message in deprecated package findings

### DIFF
--- a/src/analyzers/freshness.js
+++ b/src/analyzers/freshness.js
@@ -83,12 +83,15 @@ export async function analyzeFreshness(current, previous, options = {}) {
 
     // Check if deprecated
     if (meta.deprecated) {
+      const deprecationMsg = typeof meta.deprecated === 'string' && meta.deprecated.trim()
+        ? meta.deprecated.trim()
+        : 'No deprecation message provided.';
       findings.push({
         severity: 'warning',
         name,
         version: pkg?.version || 'unknown',
-        message: `Package is deprecated`,
-        detail: `Deprecated packages may have known vulnerabilities and should be replaced.`,
+        message: `Package is deprecated: ${deprecationMsg}`,
+        detail: `Deprecated packages may have known vulnerabilities and should be replaced. Consider migrating to an actively maintained alternative.`,
       });
     }
   }


### PR DESCRIPTION
## Description

Enhances the deprecated package detection in `src/analyzers/freshness.js` to include the actual deprecation message from the npm registry response.

### Changes
- Extracts the `deprecated` string from the npm API JSON response
- Includes the deprecation message in the warning finding so developers know why a package was deprecated and can plan migration
- Falls back to `'No deprecation message provided.'` if the field is empty or non-string

### Before
```
⚠️ Package is deprecated
  Deprecated packages may have known vulnerabilities and should be replaced.
```

### After
```
⚠️ Package is deprecated: This package has been deprecated in favor of @example/new-pkg
  Deprecated packages may have known vulnerabilities and should be replaced. Consider migrating to an actively maintained alternative.
```

Closes #4